### PR TITLE
Don't treat native-compiled functions as built-ins

### DIFF
--- a/elisp-def.el
+++ b/elisp-def.el
@@ -64,7 +64,9 @@ source code: they have e.g. org.elc but no org.el."
 (defun elisp-def--primitive-p (sym callable-p)
   "Return t if SYM is defined in C."
   (if callable-p
-      (subrp (indirect-function sym))
+      (if (fboundp 'subr-primitive-p)
+          (subr-primitive-p (indirect-function sym))
+        (subrp (indirect-function sym)))
     (let ((filename (find-lisp-object-file-name sym 'defvar)))
       (or (eq filename 'C-source)
           (and (stringp filename)


### PR DESCRIPTION
This fixes the problem where `elisp-def` hunts for a non-existent C source for native-compiled elisp functions.  The `subr-primitive-p` function is added to `subr.el` in the native-comp branch of emacs.