### PR TITLE
Support Objective-C when highlight symbol

### DIFF
--- a/elisp-def.el
+++ b/elisp-def.el
@@ -837,7 +837,7 @@ If SYM isn't present, use the most relevant symbol."
   (save-match-data
     (let (sym-end-pos)
       (cond
-       ((or (derived-mode-p 'c-mode) (derived-mode-p 'c++-mode))
+       ((or (derived-mode-p 'c-mode) (derived-mode-p 'c++-mode) (derived-mode-p 'objc-mode))
         ;; move to the quoted function/variable name string; the bound is after
         ;; two sexps: one DEFUN/DEFVAR/... followed by a parenthesised list of
         ;; arguments.


### PR DESCRIPTION
So elisp-def can scan Objective-C source files when running the NS port without getting a `"Invalid search bound (wrong side of point)"` error