### PR TITLE
Push current cursor position to general Emacs mark ring before moving to definition.

### DIFF
--- a/elisp-def.el
+++ b/elisp-def.el
@@ -907,7 +907,9 @@ If SYM isn't present, use the most relevant symbol."
 
     ;; Push the current position, so we can go back.
     (xref-push-marker-stack)
-
+    (when (not (region-active-p))
+      (push-mark))
+	
     (-let [(buf pos)
            (cond
             ((eq namespace 'bound)


### PR DESCRIPTION
 Currently ```elisp-def``` pushes current position to ```xref-marker-stack``` which is mostly used to implement ```goto definition``` behaviour. However in Emacs for functions that do not operate on symbols but do modify the cursor position (like ```goto-line```, ```end-of-buffer```) it is also a common practice to put the previous position to Emacs' buffer local ```mark-ring```.    

Actually this is exactly what ```lsp-mode``` does (in addition to pushing ```xref-marker-stack```).   

 I believe that it would be great to maintain consistency  and compatibility with ```lsp-mode``` which most Emacs users use.
Also I believe that many users do rely on a ```mark-ring``` with it's great ```counsel-mark-ring``` extension to move around in the Emacs buffer. So this patch basically pushes current cursor position with Emacs' standard ```push-mark``` before moving to definition.