### PR TITLE
Fix elisp-def--defined-in test

### DIFF
--- a/test/elisp-def-test.el
+++ b/test/elisp-def-test.el
@@ -532,7 +532,7 @@ strings."
           (list 'function 'variable)))
   (should
    (equal (elisp-def--defined-in 'eldoc)
-          (list 'library))))
+          (list 'library 'function))))
 
 (ert-deftest elisp-def--end-of-buffer ()
   "Don't crash if point is at the end of the buffer."


### PR DESCRIPTION
Evidently no one has run the tests in five years 😅. Ran into this while making
a Guix package.

PS: if you do get a chance to merge this, a tag for 1.2 would be great! But by no means required.